### PR TITLE
Fix key release/repeat event

### DIFF
--- a/VulkanEngine/VEEngine.cpp
+++ b/VulkanEngine/VEEngine.cpp
@@ -396,8 +396,7 @@ namespace ve {
 				event.subsystem == m_eventlist[i].subsystem &&
 				event.idata1 == m_eventlist[i].idata1 &&
 				event.idata2 == m_eventlist[i].idata2 &&
-				event.idata3 == m_eventlist[i].idata3 &&
-				event.idata4 == m_eventlist[i].idata4 ) {
+				event.idata3 == m_eventlist[i].idata3 ) {
 
 				uint32_t last = (uint32_t)m_eventlist.size() - 1;
 				m_eventlist[i] = m_eventlist[last];


### PR DESCRIPTION
If arbitrary key is pressed while holding any modifier key and then released **after** releasing that modifier key, repeated event won't be deleted. This also means that repeated events for modifier keys never get deleted.