### PR TITLE
Add texture support for nuklear adapter

### DIFF
--- a/VulkanEngine/VESubrenderFW_Nuklear.cpp
+++ b/VulkanEngine/VESubrenderFW_Nuklear.cpp
@@ -76,6 +76,11 @@ namespace ve {
 	VkSemaphore VESubrenderFW_Nuklear::draw(uint32_t imageIndex, VkSemaphore wait_semaphore) {
 		return nk_glfw3_render(NK_ANTI_ALIASING_ON, imageIndex, wait_semaphore);
 	}
+
+	void* VESubrenderFW_Nuklear::addTexture(VETexture* texture)
+	{
+		return nk_glfw3_add_image(texture->m_imageInfo.sampler, texture->m_imageInfo.imageView);
+	}
 }
 
 

--- a/VulkanEngine/VESubrenderFW_Nuklear.h
+++ b/VulkanEngine/VESubrenderFW_Nuklear.h
@@ -39,6 +39,8 @@ namespace ve {
 
 		///\returns the Nuklear context
 		virtual struct nk_context *getContext() { return m_ctx; };
+		///\returns texture handle
+		void *addTexture(VETexture* texture);
 
 	};
 }


### PR DESCRIPTION
I've noticed that functions like `nk_image` do not really work and it's not possible to draw images and icons in the UI, so I've fixed this. Workflow looks like this:
```
// load texture with the help of scene manager
VETexture *texture = getSceneManagerPointer()->createTexture("image", "path", "name.png");

// register texture at the UI renderer 
VESubrenderFW_Nuklear* subrender = (VESubrenderFW_Nuklear*)getRendererPointer()->getOverlay();
void *textureHandle = subrender ->addTexture(texture);

...

nk_begin(...)
...
nk_image(textureHandle);
...
nk_end(...)

```
Would probably also make sense to add a couple of helper functions in the `VESceneManager` class for managing these handles (something like `createUITexture`, `getUITexture`...)