### PR TITLE
cmake: Fix wrongly named dynamic library

### DIFF
--- a/VulkanEngine/cmake/modules/FindIrrKlang.cmake
+++ b/VulkanEngine/cmake/modules/FindIrrKlang.cmake
@@ -32,7 +32,7 @@ FIND_PATH(IRRKLANG_INCLUDE_DIR "irrKlang.h"
 # Search for the library
 SET(_irrklang_LIBRARY_NAME "irrKlang")
 if(UNIX AND NOT APPLE)
-    SET(_irrklang_LIBRARY_NAME "irrKlang.so")
+    SET(_irrklang_LIBRARY_NAME "libIrrKlang.so")
 elseif(UNIX AND APPLE)
     SET(_irrklang_LIBRARY_NAME "libirrklang.dylib")
 endif(UNIX AND NOT APPLE)


### PR DESCRIPTION
irrKlang's dynamic library is called libIrrKlang.so on Linux, instead of just irrKlang.so as one would expect (it is irrKlang.dll on Windows after all). This change fixes failing Linux builds and requires no adaption of build guides