### PR TITLE
Parallelize CPU and GPU

### DIFF
--- a/VulkanEngine/VEEngine.cpp
+++ b/VulkanEngine/VEEngine.cpp
@@ -150,6 +150,7 @@ namespace ve
 			delete m_eventListeners[(veEvent::veEventType)i];
 		}
 
+		vkDeviceWaitIdle(m_pRenderer->getDevice());
 		m_pSceneManager->closeSceneManager();
 		m_pRenderer->closeRenderer();
 		m_pWindow->closeWindow();

--- a/VulkanEngine/VEEngine.cpp
+++ b/VulkanEngine/VEEngine.cpp
@@ -600,6 +600,11 @@ namespace ve
 			m_AvgEventTime = vh::vhAverage(vh::vhTimeDuration(t_now), m_AvgEventTime);
 
 			//----------------------------------------------------------------------------------
+			//acquire the next frame before changing GPU buffers
+
+			m_pRenderer->acquireFrame();
+
+			//----------------------------------------------------------------------------------
 			//update world matrices and send them to the GPU
 
 			t_now = vh::vhTimeNow();

--- a/VulkanEngine/VEEntity.cpp
+++ b/VulkanEngine/VEEntity.cpp
@@ -517,7 +517,7 @@ namespace ve
 						m_pMesh->m_vertexBuffer, m_pMesh->m_vertexCount,
 						m_pMesh->m_indexBuffer, m_pMesh->m_indexCount,
 						m_memoryHandle.pMemBlock->buffers[0],
-						transformOffset);
+						(uint32_t)transformOffset);
 				}
 				else
 				{
@@ -528,7 +528,7 @@ namespace ve
 						m_pMesh->m_vertexBuffer, m_pMesh->m_vertexCount,
 						m_pMesh->m_indexBuffer, m_pMesh->m_indexCount,
 						m_memoryHandle.pMemBlock->buffers[0],
-						transformOffset);
+						(uint32_t)transformOffset);
 				}
 			}
 			if (getEnginePointer()->getRendererType() == veRendererType::VE_RENDERER_TYPE_RAYTRACING_KHR)
@@ -542,7 +542,7 @@ namespace ve
 						m_pMesh->m_vertexBuffer, m_pMesh->m_vertexCount,
 						m_pMesh->m_indexBuffer, m_pMesh->m_indexCount,
 						m_memoryHandle.pMemBlock->buffers[0],
-						transformOffset);
+						(uint32_t)transformOffset);
 				}
 				else
 				{
@@ -553,7 +553,7 @@ namespace ve
 						m_pMesh->m_vertexBuffer, m_pMesh->m_vertexCount,
 						m_pMesh->m_indexBuffer, m_pMesh->m_indexCount,
 						m_memoryHandle.pMemBlock->buffers[0],
-						transformOffset);
+						(uint32_t)transformOffset);
 				}
 			}
 			m_AccelerationStructure.isDirty = true;

--- a/VulkanEngine/VEEventListenerGLFW.cpp
+++ b/VulkanEngine/VEEventListenerGLFW.cpp
@@ -257,7 +257,7 @@ namespace ve
 				getEnginePointer()->getRenderer()->getGraphicsQueue(),
 				getEnginePointer()->getRenderer()->getCommandPool(),
 				image, VK_FORMAT_R8G8B8A8_UNORM,
-				VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
 				dataImage, extent.width, extent.height, imageSize);
 
 			m_numScreenshot++;

--- a/VulkanEngine/VERenderer.h
+++ b/VulkanEngine/VERenderer.h
@@ -109,6 +109,9 @@ namespace ve
 
 		virtual void destroySubrenderers();
 
+		///Wait until next frame can be drawn and acquire new frame
+		virtual void acquireFrame() {};
+
 		///Draw one frame
 		virtual void drawFrame() {};
 

--- a/VulkanEngine/VERendererDeferred.cpp
+++ b/VulkanEngine/VERendererDeferred.cpp
@@ -905,19 +905,13 @@ namespace ve
 	}
 
 	/**
-	 * \brief Draw the frame.
-	 *
-	 *- wait for draw completion using a fence, so there is at least one frame in
-	 *the swapchain
-	 *- acquire the next image from the swap chain
-	 *- update all UBOs
-	 *- get a single time command buffer from the pool, bind pipeline and begin the
-	 *render pass
-	 *- loop through all entities and draw them
-	 *- end the command buffer and submit it
-	 *- wait for the result and present it
-	 */
-	void VERendererDeferred::drawFrame()
+	* \brief Acquire the next frame.
+	*
+	*- wait for draw completion using a fence, so there is at least one frame in
+	*the swapchain
+	*- acquire the next image from the swap chain
+	*/
+	void VERendererDeferred::acquireFrame()
 	{
 		vkWaitForFences(m_device, 1, &m_inFlightFences[m_currentFrame], VK_TRUE,
 			std::numeric_limits<uint64_t>::max());
@@ -939,6 +933,20 @@ namespace ve
 			exit(1);
 		}
 
+	}
+
+	/**
+	 * \brief Draw the frame.
+	 *
+	 *- update all UBOs
+	 *- get a single time command buffer from the pool, bind pipeline and begin the
+	 *render pass
+	 *- loop through all entities and draw them
+	 *- end the command buffer and submit it
+	 *- wait for the result and present it
+	 */
+	void VERendererDeferred::drawFrame()
+	{
 		if (m_commandBuffersWithPendingUpdate[m_imageIndex])
 		{
 			vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffersOffscreen[m_imageIndex]);

--- a/VulkanEngine/VERendererDeferred.cpp
+++ b/VulkanEngine/VERendererDeferred.cpp
@@ -80,10 +80,12 @@ namespace ve
 
 		m_commandBuffersOffscreen.resize(m_swapChainImages.size());
 		m_commandBuffersOnscreen.resize(m_swapChainImages.size());
+		m_commandBuffersWithPendingUpdate.resize(m_swapChainImages.size());
 		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
 		{
 			m_commandBuffersOffscreen[i] = VK_NULL_HANDLE; // will be created later
 			m_commandBuffersOnscreen[i] = VK_NULL_HANDLE; // will be created later
+			m_commandBuffersWithPendingUpdate[i] = false;
 		}
 
 		m_secondaryBuffersOffscreen.resize(m_swapChainImages.size());
@@ -335,16 +337,6 @@ namespace ve
 
 		//------------------------------------------------------------------------------------------------------------
 
-		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
-		{
-			vh::vhBufTransitionImageLayout(
-				m_device, m_graphicsQueue,
-				m_commandPool, // transition the image layout to
-				m_swapChainImages[i], VK_FORMAT_R8G8B8A8_UNORM,
-				VK_IMAGE_ASPECT_COLOR_BIT, 1, 1, // VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-				VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-		}
-
 		createSyncObjects();
 
 		createSubrenderers();
@@ -451,6 +443,7 @@ namespace ve
 			vkDestroySemaphore(m_device, m_renderFinishedSemaphores[i], nullptr);
 			vkDestroySemaphore(m_device, m_offscreenSemaphores[i], nullptr);
 			vkDestroySemaphore(m_device, m_imageAvailableSemaphores[i], nullptr);
+			vkDestroySemaphore(m_device, m_overlaySemaphores[i], nullptr);
 			vkDestroyFence(m_device, m_inFlightFences[i], nullptr);
 		}
 
@@ -610,6 +603,8 @@ namespace ve
 					&m_offscreenSemaphores[i]) != VK_SUCCESS ||
 				vkCreateSemaphore(m_device, &semaphoreInfo, nullptr,
 					&m_renderFinishedSemaphores[i]) != VK_SUCCESS ||
+				vkCreateSemaphore(m_device, &semaphoreInfo, nullptr,
+					&m_overlaySemaphores[i]) != VK_SUCCESS ||
 				vkCreateFence(m_device, &fenceInfo, nullptr, &m_inFlightFences[i]) !=
 				VK_SUCCESS)
 			{
@@ -620,6 +615,21 @@ namespace ve
 	}
 
 	//--------------------------------------------------------------------------------------------
+
+	/**
+		* \brief Queue an update for all command buffers, so next time they have to be
+		* deleted, recreated and recorded again
+		*/
+	void VERendererDeferred::updateCmdBuffers()
+	{
+		for (uint32_t i = 0; i < m_commandBuffersOffscreen.size(); i++)
+		{
+			if (m_commandBuffersOffscreen[i] != VK_NULL_HANDLE)
+			{
+				m_commandBuffersWithPendingUpdate[i] = true;
+			}
+		}
+	}
 
 	/**
 	 * \brief Delete all command buffers and set them to VK_NULL_HANDLE, so next
@@ -644,6 +654,7 @@ namespace ve
 					&m_commandBuffersOnscreen[i]);
 				m_commandBuffersOnscreen[i] = VK_NULL_HANDLE;
 			}
+			m_commandBuffersWithPendingUpdate[i] = false;
 		}
 	}
 
@@ -873,12 +884,18 @@ namespace ve
 				&m_secondaryBuffersOnscreen[m_imageIndex][bufferIdx++].buffer);
 			vkCmdEndRenderPass(m_commandBuffersOnscreen[m_imageIndex]);
 		}
+
+		if (m_subrenderOverlay == nullptr) {
+			// without overlay renderer we must transition the image to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+			vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
+				m_commandBuffersOnscreen[m_imageIndex], //transition the image layout to
+				getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
+				1, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+		}
+
 		vkEndCommandBuffer(m_commandBuffersOnscreen[m_imageIndex]);
 
 		m_AvgRecordTimeOnscreen = vh::vhAverage(vh::vhTimeDuration(t_start), m_AvgRecordTimeOnscreen, 1.0f / m_swapChainImages.size());
-
-		// m_overlaySemaphores[m_currentFrame] =
-		// m_renderFinishedSemaphores[m_currentFrame];
 
 		// remember the last recorded entities, for incremental recording
 		for (auto subrender : m_subrenderers)
@@ -922,6 +939,15 @@ namespace ve
 			exit(1);
 		}
 
+		if (m_commandBuffersWithPendingUpdate[m_imageIndex])
+		{
+			vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffersOffscreen[m_imageIndex]);
+			m_commandBuffersOffscreen[m_imageIndex] = VK_NULL_HANDLE;
+			vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffersOnscreen[m_imageIndex]);
+			m_commandBuffersOnscreen[m_imageIndex] = VK_NULL_HANDLE;
+			m_commandBuffersWithPendingUpdate[m_imageIndex] = false;
+		}
+
 		if (m_commandBuffersOffscreen[m_imageIndex] == VK_NULL_HANDLE)
 		{
 			recordCmdBuffersOffscreen();
@@ -930,14 +956,6 @@ namespace ve
 		{
 			recordCmdBuffersOnscreen();
 		}
-
-		vh::vhBufTransitionImageLayout(
-			m_device, m_graphicsQueue,
-			m_commandPool, // transition the image layout to
-			getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT,
-			1, 1, // VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-			VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
 		// submit the command buffers
 		vh::vhCmdSubmitCommandBuffer(
@@ -967,11 +985,12 @@ namespace ve
 	 */
 	void VERendererDeferred::drawOverlay()
 	{
+		assert(m_subrenderOverlay != nullptr); // needs same change as in VERendererForward
 		if (m_subrenderOverlay == nullptr)
 			return;
 
-		m_overlaySemaphores[m_currentFrame] = m_subrenderOverlay->draw(
-			m_imageIndex, m_renderFinishedSemaphores[m_currentFrame]);
+		m_subrenderOverlay->draw(
+			m_imageIndex, m_renderFinishedSemaphores[m_currentFrame], m_overlaySemaphores[m_currentFrame]);
 	}
 
 	/**
@@ -981,14 +1000,6 @@ namespace ve
 	 */
 	void VERendererDeferred::presentFrame()
 	{
-		vh::vhBufTransitionImageLayout(
-			m_device, m_graphicsQueue,
-			m_commandPool, // transition the image layout to
-			getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT,
-			1, 1, // VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-			VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-
 		VkResult result = vh::vhRenderPresentResult(
 			m_presentQueue, m_swapChain, m_imageIndex, // present it to the swap chain
 			m_overlaySemaphores[m_currentFrame]);

--- a/VulkanEngine/VERendererDeferred.h
+++ b/VulkanEngine/VERendererDeferred.h
@@ -30,6 +30,7 @@ namespace ve
 		std::vector<VkCommandPool> m_commandPools = {}; ///<Array of command pools so that each thread in the thread pool has its own pool
 		std::vector<VkCommandBuffer> m_commandBuffersOffscreen = {}; ///<the main command buffers for recording draw commands
 		std::vector<VkCommandBuffer> m_commandBuffersOnscreen = {}; ///<the main command buffers for recording draw commands
+		std::vector<bool> m_commandBuffersWithPendingUpdate = {}; ///<flag storing if command buffer must be rerecorded
 		std::vector<std::vector<secondaryCmdBuf_t>> m_secondaryBuffersOffscreen = {}; ///<secondary buffers for parallel recording
 		std::vector<std::vector<std::future<secondaryCmdBuf_t>>>
 			m_secondaryBuffersOnscreenFutures = {}; ///<secondary buffers for parallel recording
@@ -107,10 +108,7 @@ namespace ve
 			return m_commandPools[getEnginePointer()->getThreadPool()->threadNum[std::this_thread::get_id()]];
 		};
 
-		virtual void updateCmdBuffers()
-		{
-			deleteCmdBuffers();
-		};
+		virtual void updateCmdBuffers();
 
 		virtual void deleteCmdBuffers();
 

--- a/VulkanEngine/VERendererDeferred.h
+++ b/VulkanEngine/VERendererDeferred.h
@@ -79,6 +79,7 @@ namespace ve
 		virtual void recordCmdBuffersOffscreen(); //record the command buffers
 		virtual void recordCmdBuffersOnscreen(); //record the command buffers
 
+		virtual void acquireFrame(); //acquire the next frame
 		virtual void drawFrame(); //draw one frame
 		virtual void prepareOverlay(); //prepare to draw the overlay
 		virtual void drawOverlay(); //Draw the overlay (GUI)

--- a/VulkanEngine/VERendererForward.cpp
+++ b/VulkanEngine/VERendererForward.cpp
@@ -765,14 +765,12 @@ namespace ve
 	}
 
 	/**
-		* \brief Draw the frame.
+		* \brief Acquire the next frame.
 		*
 		*- wait for draw completion using a fence of a previous cmd buffer
 		*- acquire the next image from the swap chain
-		*- if there is no command buffer yet, record one with the current scene
-		*- submit it to the queue
 		*/
-	void VERendererForward::drawFrame()
+	void VERendererForward::acquireFrame()
 	{
 		vkWaitForFences(m_device, 1, &m_inFlightFences[m_currentFrame], VK_TRUE, std::numeric_limits<uint64_t>::max());
 
@@ -780,7 +778,6 @@ namespace ve
 		VkResult result = vkAcquireNextImageKHR(m_device, m_swapChain, std::numeric_limits<uint64_t>::max(),
 			m_imageAvailableSemaphores[m_currentFrame], VK_NULL_HANDLE,
 			&m_imageIndex);
-
 		if (result == VK_ERROR_OUT_OF_DATE_KHR)
 		{
 			recreateSwapchain();
@@ -791,7 +788,16 @@ namespace ve
 			assert(false);
 			exit(1);
 		}
+	}
 
+	/**
+		* \brief Draw the frame.
+		*
+		*- if there is no command buffer yet, record one with the current scene
+		*- submit it to the queue
+		*/
+	void VERendererForward::drawFrame()
+	{
 		if (m_commandBuffersWithPendingUpdate[m_imageIndex])
 		{
 			vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffers[m_imageIndex]);

--- a/VulkanEngine/VERendererForward.h
+++ b/VulkanEngine/VERendererForward.h
@@ -77,6 +77,7 @@ namespace ve
 
 		void recordPrimaryBuffers();
 
+		virtual void acquireFrame(); //acquire the next frame
 		virtual void drawFrame(); //draw one frame
 		virtual void prepareOverlay(); //prepare to draw the overlay
 		virtual void drawOverlay(); //Draw the overlay (GUI)

--- a/VulkanEngine/VERendererForward.h
+++ b/VulkanEngine/VERendererForward.h
@@ -26,6 +26,7 @@ namespace ve
 	protected:
 		std::vector<VkCommandPool> m_commandPools = {}; ///<Array of command pools so that each thread in the thread pool has its own pool
 		std::vector<VkCommandBuffer> m_commandBuffers = {}; ///<the main command buffers for recording draw commands
+		std::vector<bool> m_commandBuffersWithPendingUpdate = {}; ///<flag storing if command buffer must be rerecorded
 		std::vector<std::vector<std::future<secondaryCmdBuf_t>>>
 			m_secondaryBuffersFutures = {}; ///<secondary buffers for parallel recording
 		std::vector<std::vector<secondaryCmdBuf_t>> m_secondaryBuffers = {}; ///<secondary buffers for parallel recording
@@ -106,10 +107,7 @@ namespace ve
 		};
 
 		///called whenever the scene graph of the scene manager changes
-		virtual void updateCmdBuffers()
-		{
-			deleteCmdBuffers();
-		};
+		virtual void updateCmdBuffers();
 
 		virtual void deleteCmdBuffers();
 

--- a/VulkanEngine/VERendererRayTracingKHR.cpp
+++ b/VulkanEngine/VERendererRayTracingKHR.cpp
@@ -440,14 +440,12 @@ namespace ve
 	}
 
 	/**
-		* \brief Draw the frame.
-		*
-		*- wait for draw completion using a fence of a previous cmd buffer
-		*- acquire the next image from the swap chain
-		*- if there is no command buffer yet, record one with the current scene
-		*- submit it to the queue
-		*/
-	void VERendererRayTracingKHR::drawFrame()
+	* \brief Acquire the next frame.
+	*
+	*- wait for draw completion using a fence of a previous cmd buffer
+	*- acquire the next image from the swap chain
+	*/
+	void VERendererRayTracingKHR::acquireFrame()
 	{
 		vkWaitForFences(m_device, 1, &m_inFlightFences[m_currentFrame], VK_TRUE, std::numeric_limits<uint64_t>::max());
 
@@ -466,7 +464,16 @@ namespace ve
 			assert(false);
 			exit(1);
 		}
+	}
 
+	/**
+		* \brief Draw the frame.
+		*
+		*- if there is no command buffer yet, record one with the current scene
+		*- submit it to the queue
+		*/
+	void VERendererRayTracingKHR::drawFrame()
+	{
 		//create tlas if not existing
 		//update tlas, if at least one blas is dirty
 		updateTLAS();

--- a/VulkanEngine/VERendererRayTracingKHR.cpp
+++ b/VulkanEngine/VERendererRayTracingKHR.cpp
@@ -85,8 +85,11 @@ namespace ve
 		}
 
 		m_commandBuffers.resize(m_swapChainImages.size());
-		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
+		m_commandBuffersWithPendingUpdate.resize(m_swapChainImages.size());
+		for (uint32_t i = 0; i < m_swapChainImages.size(); i++) {
 			m_commandBuffers[i] = VK_NULL_HANDLE; //will be created later
+			m_commandBuffersWithPendingUpdate[i] = false;
+		}
 
 		m_secondaryBuffers.resize(m_swapChainImages.size());
 		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
@@ -138,15 +141,6 @@ namespace ve
 			&m_descriptorSetLayoutPerObject));
 
 		//------------------------------------------------------------------------------------------------------------
-
-		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
-		{
-			vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
-				m_commandPool, //transition the image layout to
-				m_swapChainImages[i], VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
-				1, //VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-				VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-		}
 
 		createSyncObjects();
 
@@ -220,6 +214,7 @@ namespace ve
 		{
 			vkDestroySemaphore(m_device, m_renderFinishedSemaphores[i], nullptr);
 			vkDestroySemaphore(m_device, m_imageAvailableSemaphores[i], nullptr);
+			vkDestroySemaphore(m_device, m_overlaySemaphores[i], nullptr);
 			vkDestroyFence(m_device, m_inFlightFences[i], nullptr);
 		}
 
@@ -315,6 +310,7 @@ namespace ve
 		{
 			if (vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_imageAvailableSemaphores[i]) != VK_SUCCESS ||
 				vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_renderFinishedSemaphores[i]) != VK_SUCCESS ||
+				vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_overlaySemaphores[i]) != VK_SUCCESS ||
 				vkCreateFence(m_device, &fenceInfo, nullptr, &m_inFlightFences[i]) != VK_SUCCESS)
 			{
 				assert(false);
@@ -326,7 +322,13 @@ namespace ve
 	void VERendererRayTracingKHR::updateCmdBuffers()
 	{
 		vh::vhDestroyAccelerationStructure(m_device, m_vmaAllocator, m_topLevelAS);
-		deleteCmdBuffers();
+		for (uint32_t i = 0; i < m_commandBuffers.size(); i++)
+		{
+			if (m_commandBuffers[i] != VK_NULL_HANDLE)
+			{
+				m_commandBuffersWithPendingUpdate[i] = true;
+			}
+		}
 	};
 
 	/**
@@ -341,6 +343,7 @@ namespace ve
 			{
 				vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffers[i]);
 				m_commandBuffers[i] = VK_NULL_HANDLE;
+				m_commandBuffersWithPendingUpdate[i] = false;
 			}
 		}
 	}
@@ -422,9 +425,15 @@ namespace ve
 		}
 		m_AvgRecordTimeOnscreen = vh::vhAverage(vh::vhTimeDuration(t_start), m_AvgRecordTimeOnscreen, 1.0f / m_swapChainImages.size());
 
-		vkEndCommandBuffer(m_commandBuffers[m_imageIndex]);
+		if (m_subrenderOverlay == nullptr) {
+			// without overlay renderer we must transition the image to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+			vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
+				m_commandBuffers[m_imageIndex], //transition the image layout to
+				getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
+				1, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+		}
 
-		m_overlaySemaphores[m_currentFrame] = m_renderFinishedSemaphores[m_currentFrame];
+		vkEndCommandBuffer(m_commandBuffers[m_imageIndex]);
 
 		//remember the last recorded entities, for incremental recording
 		m_subrenderRT->afterDrawFinished();
@@ -462,16 +471,17 @@ namespace ve
 		//update tlas, if at least one blas is dirty
 		updateTLAS();
 
+		if (m_commandBuffersWithPendingUpdate[m_imageIndex])
+		{
+			vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffers[m_imageIndex]);
+			m_commandBuffers[m_imageIndex] = VK_NULL_HANDLE;
+			m_commandBuffersWithPendingUpdate[m_imageIndex] = false;
+		}
+
 		if (m_commandBuffers[m_imageIndex] == VK_NULL_HANDLE)
 		{
 			recordCmdBuffers();
 		}
-
-		vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
-			m_commandPool, //transition the image layout to
-			getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
-			1, //VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-			VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_IMAGE_LAYOUT_GENERAL);
 
 		//submit the command buffers
 		vh::vhCmdSubmitCommandBuffer(m_device, m_graphicsQueue, m_commandBuffers[m_imageIndex],
@@ -498,8 +508,9 @@ namespace ve
 		if (m_subrenderOverlay == nullptr)
 			return;
 
-		m_overlaySemaphores[m_currentFrame] = m_subrenderOverlay->draw(m_imageIndex,
-			m_renderFinishedSemaphores[m_currentFrame]);
+		// overlay renderer must transition image (color attachment) to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+		m_subrenderOverlay->draw(m_imageIndex,
+			m_renderFinishedSemaphores[m_currentFrame], m_overlaySemaphores[m_currentFrame]);
 	}
 
 	/**
@@ -507,12 +518,6 @@ namespace ve
 		*/
 	void VERendererRayTracingKHR::presentFrame()
 	{
-		vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
-			m_commandPool, //transition the image layout to
-			getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
-			1, //VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-			VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-
 		VkResult result = vh::vhRenderPresentResult(m_presentQueue, m_swapChain,
 			m_imageIndex, //present it to the swap chain
 			m_overlaySemaphores[m_currentFrame]);

--- a/VulkanEngine/VERendererRayTracingKHR.cpp
+++ b/VulkanEngine/VERendererRayTracingKHR.cpp
@@ -117,7 +117,7 @@ namespace ve
 			m_swapChainFramebuffers);
 
 		uint32_t maxobjects = 200;
-		uint32_t storageobjects = m_swapChainImageViews.size();
+		uint32_t storageobjects = (uint32_t)m_swapChainImageViews.size();
 		VECHECKRESULT(vh::vhRenderCreateDescriptorPool(m_device,
 			{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
 			 VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR,

--- a/VulkanEngine/VERendererRayTracingKHR.h
+++ b/VulkanEngine/VERendererRayTracingKHR.h
@@ -105,6 +105,7 @@ namespace ve
 
 		std::vector<VkCommandPool> m_commandPools = {}; ///<Array of command pools so that each thread in the thread pool has its own pool
 		std::vector<VkCommandBuffer> m_commandBuffers = {}; ///<the main command buffers for recording draw commands
+		std::vector<bool> m_commandBuffersWithPendingUpdate = {}; ///<flag storing if command buffer must be rerecorded
 
 		VkRenderPass m_renderPass;
 

--- a/VulkanEngine/VERendererRayTracingKHR.h
+++ b/VulkanEngine/VERendererRayTracingKHR.h
@@ -71,6 +71,7 @@ namespace ve
 		virtual void initRenderer(); //init the renderer
 		virtual void recordCmdBuffers(); //record the command buffers
 
+		virtual void acquireFrame(); //acquire the next frame
 		virtual void drawFrame(); //draw one frame
 		virtual void prepareOverlay(); //prepare to draw the overlay
 		virtual void drawOverlay(); //Draw the overlay (GUI)

--- a/VulkanEngine/VERendererRayTracingNV.cpp
+++ b/VulkanEngine/VERendererRayTracingNV.cpp
@@ -415,14 +415,12 @@ namespace ve
 	}
 
 	/**
-		* \brief Draw the frame.
+		* \brief Acquire the next frame.
 		*
 		*- wait for draw completion using a fence of a previous cmd buffer
 		*- acquire the next image from the swap chain
-		*- if there is no command buffer yet, record one with the current scene
-		*- submit it to the queue
 		*/
-	void VERendererRayTracingNV::drawFrame()
+	void VERendererRayTracingNV::acquireFrame()
 	{
 		vkWaitForFences(m_device, 1, &m_inFlightFences[m_currentFrame], VK_TRUE, std::numeric_limits<uint64_t>::max());
 
@@ -441,7 +439,16 @@ namespace ve
 			assert(false);
 			exit(1);
 		}
+	}
 
+	/**
+		* \brief Draw the frame.
+		*
+		*- if there is no command buffer yet, record one with the current scene
+		*- submit it to the queue
+		*/
+	void VERendererRayTracingNV::drawFrame()
+	{
 		//create tlas if not existing
 		//update tlas, if at least one blas is dirty
 		updateTLAS();

--- a/VulkanEngine/VERendererRayTracingNV.cpp
+++ b/VulkanEngine/VERendererRayTracingNV.cpp
@@ -63,8 +63,11 @@ namespace ve
 		}
 
 		m_commandBuffers.resize(m_swapChainImages.size());
-		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
+		m_commandBuffersWithPendingUpdate.resize(m_swapChainImages.size());
+		for (uint32_t i = 0; i < m_swapChainImages.size(); i++) {
 			m_commandBuffers[i] = VK_NULL_HANDLE; //will be created later
+			m_commandBuffersWithPendingUpdate[i] = false;
+		}
 
 		m_secondaryBuffers.resize(m_swapChainImages.size());
 		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
@@ -117,15 +120,6 @@ namespace ve
 			&m_descriptorSetLayoutPerObject));
 
 		//------------------------------------------------------------------------------------------------------------
-
-		for (uint32_t i = 0; i < m_swapChainImages.size(); i++)
-		{
-			vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
-				m_commandPool, //transition the image layout to
-				m_swapChainImages[i], VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
-				1, //VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-				VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-		}
 
 		createSyncObjects();
 
@@ -195,6 +189,7 @@ namespace ve
 		{
 			vkDestroySemaphore(m_device, m_renderFinishedSemaphores[i], nullptr);
 			vkDestroySemaphore(m_device, m_imageAvailableSemaphores[i], nullptr);
+			vkDestroySemaphore(m_device, m_overlaySemaphores[i], nullptr);
 			vkDestroyFence(m_device, m_inFlightFences[i], nullptr);
 		}
 
@@ -264,6 +259,7 @@ namespace ve
 		{
 			if (vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_imageAvailableSemaphores[i]) != VK_SUCCESS ||
 				vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_renderFinishedSemaphores[i]) != VK_SUCCESS ||
+				vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_overlaySemaphores[i]) != VK_SUCCESS ||
 				vkCreateFence(m_device, &fenceInfo, nullptr, &m_inFlightFences[i]) != VK_SUCCESS)
 			{
 				assert(false);
@@ -275,7 +271,13 @@ namespace ve
 	void VERendererRayTracingNV::updateCmdBuffers()
 	{
 		vh::vhDestroyAccelerationStructure(m_device, m_vmaAllocator, m_topLevelAS);
-		deleteCmdBuffers();
+		for (uint32_t i = 0; i < m_commandBuffers.size(); i++)
+		{
+			if (m_commandBuffers[i] != VK_NULL_HANDLE)
+			{
+				m_commandBuffersWithPendingUpdate[i] = true;
+			}
+		}
 	};
 
 	/**
@@ -290,6 +292,7 @@ namespace ve
 			{
 				vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffers[i]);
 				m_commandBuffers[i] = VK_NULL_HANDLE;
+				m_commandBuffersWithPendingUpdate[i] = false;
 			}
 		}
 	}
@@ -397,9 +400,15 @@ namespace ve
 		}
 		m_AvgRecordTimeOnscreen = vh::vhAverage(vh::vhTimeDuration(t_start), m_AvgRecordTimeOnscreen, 1.0f/m_swapChainImages.size());
 
-		vkEndCommandBuffer(m_commandBuffers[m_imageIndex]);
+		if (m_subrenderOverlay == nullptr) {
+			// without overlay renderer we must transition the image to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+			vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
+				m_commandBuffers[m_imageIndex], //transition the image layout to
+				getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
+				1, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+		}
 
-		m_overlaySemaphores[m_currentFrame] = m_renderFinishedSemaphores[m_currentFrame];
+		vkEndCommandBuffer(m_commandBuffers[m_imageIndex]);
 
 		//remember the last recorded entities, for incremental recording
 		m_subrenderRT->afterDrawFinished();
@@ -437,16 +446,17 @@ namespace ve
 		//update tlas, if at least one blas is dirty
 		updateTLAS();
 
+		if (m_commandBuffersWithPendingUpdate[m_imageIndex])
+		{
+			vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffers[m_imageIndex]);
+			m_commandBuffers[m_imageIndex] = VK_NULL_HANDLE;
+			m_commandBuffersWithPendingUpdate[m_imageIndex] = false;
+		}
+
 		if (m_commandBuffers[m_imageIndex] == VK_NULL_HANDLE)
 		{
 			recordCmdBuffers();
 		}
-
-		vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
-			m_commandPool, //transition the image layout to
-			getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
-			1, //VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-			VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
 		//submit the command buffers
 		vh::vhCmdSubmitCommandBuffer(m_device, m_graphicsQueue, m_commandBuffers[m_imageIndex],
@@ -473,8 +483,9 @@ namespace ve
 		if (m_subrenderOverlay == nullptr)
 			return;
 
-		m_overlaySemaphores[m_currentFrame] = m_subrenderOverlay->draw(m_imageIndex,
-			m_renderFinishedSemaphores[m_currentFrame]);
+		// overlay renderer must transition image (color attachment) to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+		m_subrenderOverlay->draw(m_imageIndex,
+			m_renderFinishedSemaphores[m_currentFrame], m_overlaySemaphores[m_currentFrame]);
 	}
 
 	/**
@@ -482,12 +493,6 @@ namespace ve
 		*/
 	void VERendererRayTracingNV::presentFrame()
 	{
-		vh::vhBufTransitionImageLayout(m_device, m_graphicsQueue,
-			m_commandPool, //transition the image layout to
-			getSwapChainImage(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1,
-			1, //VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-			VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-
 		VkResult result = vh::vhRenderPresentResult(m_presentQueue, m_swapChain,
 			m_imageIndex, //present it to the swap chain
 			m_overlaySemaphores[m_currentFrame]);

--- a/VulkanEngine/VERendererRayTracingNV.cpp
+++ b/VulkanEngine/VERendererRayTracingNV.cpp
@@ -95,7 +95,7 @@ namespace ve
 			m_swapChainFramebuffers);
 
 		uint32_t maxobjects = 200;
-		uint32_t storageobjects = m_swapChainImageViews.size();
+		uint32_t storageobjects = (uint32_t)m_swapChainImageViews.size();
 		VECHECKRESULT(vh::vhRenderCreateDescriptorPool(m_device,
 			{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
 			 VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV,

--- a/VulkanEngine/VERendererRayTracingNV.h
+++ b/VulkanEngine/VERendererRayTracingNV.h
@@ -102,6 +102,7 @@ namespace ve
 
 		std::vector<VkCommandPool> m_commandPools = {}; ///<Array of command pools so that each thread in the thread pool has its own pool
 		std::vector<VkCommandBuffer> m_commandBuffers = {}; ///<the main command buffers for recording draw commands
+		std::vector<bool> m_commandBuffersWithPendingUpdate = {}; ///<flag storing if command buffer must be rerecorded
 
 		VkRenderPass m_renderPass; ///<The first light render pass, clearing the framebuffers
 		

--- a/VulkanEngine/VERendererRayTracingNV.h
+++ b/VulkanEngine/VERendererRayTracingNV.h
@@ -68,6 +68,7 @@ namespace ve
 		virtual void initRenderer(); //init the renderer
 		virtual void recordCmdBuffers(); //record the command buffers
 
+		virtual void acquireFrame(); //acquire the next frame
 		virtual void drawFrame(); //draw one frame
 		virtual void prepareOverlay(); //prepare to draw the overlay
 		virtual void drawOverlay(); //Draw the overlay (GUI)

--- a/VulkanEngine/VESubrender.h
+++ b/VulkanEngine/VESubrender.h
@@ -71,11 +71,7 @@ namespace ve
 		virtual void draw(VkCommandBuffer commandBuffer, uint32_t imageIndex, uint32_t numPass, VECamera *pCamera, VELight *pLight, std::vector<VkDescriptorSet> descriptorSetsShadow = {}) {};
 
 		///Perform an arbitrary draw operation
-		///\returns a semaphore signalling when this draw operations has finished
-		virtual VkSemaphore draw(uint32_t imageIndex, VkSemaphore wait_semaphore)
-		{
-			return VK_NULL_HANDLE;
-		};
+		virtual void draw(uint32_t imageIndex, VkSemaphore wait_semaphore, VkSemaphore signal_semaphore) {};
 
 		///\brief draw a specific entity
 		virtual void drawEntity(VkCommandBuffer commandBuffer, uint32_t imageIndex, VEEntity *entity) {};

--- a/VulkanEngine/VESubrenderDF.cpp
+++ b/VulkanEngine/VESubrenderDF.cpp
@@ -257,6 +257,10 @@ namespace ve
 			}
 		}
 
+		// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+		// this happens if entities are added or removed
+		vkQueueWaitIdle(m_renderer.getGraphicsQueue());
+
 		vh::vhRenderUpdateDescriptorSetMaps(m_renderer.getDevice(), //update the descriptor that holds the map array
 			m_descriptorSetsResources[m_descriptorSetsResources.size() - 1],
 			0,
@@ -294,6 +298,10 @@ namespace ve
 					{ //move also the map entries
 						m_maps[j][i] = m_maps[j][size - 1];
 					}
+
+					// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+					// this happens if entities are added or removed
+					vkQueueWaitIdle(m_renderer.getGraphicsQueue());
 
 					//update the descriptor set where the entity was removed
 					uint32_t arrayIndex = (uint32_t)(i / m_resourceArrayLength);

--- a/VulkanEngine/VESubrenderDF.h
+++ b/VulkanEngine/VESubrenderDF.h
@@ -75,13 +75,6 @@ namespace ve
 		virtual void
 			draw(VkCommandBuffer commandBuffer, uint32_t imageIndex, uint32_t numPass, VECamera *pCamera, VELight *pLight, std::vector<VkDescriptorSet> descriptorSetsShadow) override;
 
-		///Perform an arbitrary draw operation
-		///\returns a semaphore signalling when this draw operations has finished
-		virtual VkSemaphore draw(uint32_t imageIndex, VkSemaphore wait_semaphore) override
-		{
-			return VK_NULL_HANDLE;
-		};
-
 		virtual void drawEntity(VkCommandBuffer commandBuffer, uint32_t imageIndex, VEEntity *entity) override;
 
 		//------------------------------------------------------------------------------------------------------------------

--- a/VulkanEngine/VESubrenderFW.cpp
+++ b/VulkanEngine/VESubrenderFW.cpp
@@ -267,6 +267,10 @@ namespace ve
 			}
 		}
 
+		// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+		// this happens if entities are added or removed
+		vkQueueWaitIdle(m_renderer.getGraphicsQueue());
+
 		vh::vhRenderUpdateDescriptorSetMaps(m_renderer.getDevice(), //update the descriptor that holds the map array
 			m_descriptorSetsResources[m_descriptorSetsResources.size() - 1],
 			0,
@@ -304,6 +308,10 @@ namespace ve
 					{ //move also the map entries
 						m_maps[j][i] = m_maps[j][size - 1];
 					}
+
+					// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+					// this happens if entities are added or removed
+					vkQueueWaitIdle(m_renderer.getGraphicsQueue());
 
 					//update the descriptor set where the entity was removed
 					uint32_t arrayIndex = (uint32_t)(i / m_resourceArrayLength);

--- a/VulkanEngine/VESubrenderRayTracingKHR.cpp
+++ b/VulkanEngine/VESubrenderRayTracingKHR.cpp
@@ -240,6 +240,10 @@ namespace ve
 			}
 		}
 
+		// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+		// this happens if entities are added or removed
+		vkQueueWaitIdle(m_renderer.getGraphicsQueue());
+
 		vh::vhRenderUpdateDescriptorSetMaps(m_renderer.getDevice(), //update the descriptor that holds the map array
 			m_descriptorSetsResources[m_descriptorSetsResources.size() - 1],
 			0,
@@ -277,6 +281,10 @@ namespace ve
 					{ //move also the map entries
 						m_maps[j][i] = m_maps[j][size - 1];
 					}
+
+					// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+					// this happens if entities are added or removed
+					vkQueueWaitIdle(m_renderer.getGraphicsQueue());
 
 					//update the descriptor set where the entity was removed
 					uint32_t arrayIndex = (uint32_t)(i / m_resourceArrayLength);

--- a/VulkanEngine/VESubrenderRayTracingNV.cpp
+++ b/VulkanEngine/VESubrenderRayTracingNV.cpp
@@ -247,6 +247,10 @@ namespace ve
 			}
 		}
 
+		// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+		// this happens if entities are added or removed
+		vkQueueWaitIdle(m_renderer.getGraphicsQueue());
+
 		vh::vhRenderUpdateDescriptorSetMaps(m_renderer.getDevice(), //update the descriptor that holds the map array
 			m_descriptorSetsResources[m_descriptorSetsResources.size() - 1],
 			0,
@@ -284,6 +288,10 @@ namespace ve
 					{ //move also the map entries
 						m_maps[j][i] = m_maps[j][size - 1];
 					}
+
+					// workaround for synchronization problem: there must not be a command buffer in pending state while updating descriptor sets
+					// this happens if entities are added or removed
+					vkQueueWaitIdle(m_renderer.getGraphicsQueue());
 
 					//update the descriptor set where the entity was removed
 					uint32_t arrayIndex = (uint32_t)(i / m_resourceArrayLength);

--- a/VulkanEngine/VESubrender_Nuklear.cpp
+++ b/VulkanEngine/VESubrender_Nuklear.cpp
@@ -73,11 +73,11 @@ namespace ve
 		nk_glfw3_new_frame();
 	}
 
-	VkSemaphore VESubrender_Nuklear::draw(uint32_t
+	void VESubrender_Nuklear::draw(uint32_t
 		imageIndex,
-		VkSemaphore wait_semaphore)
+		VkSemaphore wait_semaphore, VkSemaphore signal_semaphore)
 	{
-		return nk_glfw3_render(NK_ANTI_ALIASING_ON, imageIndex, wait_semaphore);
+		nk_glfw3_render(NK_ANTI_ALIASING_ON, imageIndex, wait_semaphore, signal_semaphore);
 	}
 
 	void *VESubrender_Nuklear::addTexture(VETexture *texture)

--- a/VulkanEngine/VESubrender_Nuklear.h
+++ b/VulkanEngine/VESubrender_Nuklear.h
@@ -49,7 +49,7 @@ namespace ve
 
 		virtual void draw(VkCommandBuffer commandBuffer, uint32_t imageIndex, uint32_t numPass, VECamera *pCamera, VELight *pLight, std::vector<VkDescriptorSet> descriptorSetsShadow) {};
 
-		virtual VkSemaphore draw(uint32_t imageIndex, VkSemaphore wait_semaphore);
+		virtual void draw(uint32_t imageIndex, VkSemaphore wait_semaphore, VkSemaphore signal_semaphore);
 
 		///\returns the Nuklear context
 		virtual struct nk_context *getContext()

--- a/VulkanEngine/VHBuffer.cpp
+++ b/VulkanEngine/VHBuffer.cpp
@@ -447,6 +447,15 @@ namespace vh
 			sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 			destinationStage = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
 		}
+		else if (oldLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL &&
+			newLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
+		{
+			barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+			barrier.dstAccessMask = 0;				
+
+			sourceStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			destinationStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		}
 
 		vkCmdPipelineBarrier(commandBuffer,
 			sourceStage, destinationStage,

--- a/VulkanEngine/VHHelper.h
+++ b/VulkanEngine/VHHelper.h
@@ -365,7 +365,7 @@ namespace vh
 
 	//--------------------------------------------------------------------------------------------------------------------------------
 	//rendering
-	VkResult vhRenderCreateRenderPass(VkDevice device, VkFormat swapChainImageFormat, VkFormat depthFormat, VkAttachmentLoadOp loadOp, VkRenderPass *renderPass);
+	VkResult vhRenderCreateRenderPass(VkDevice device, VkFormat swapChainImageFormat, VkFormat depthFormat, VkAttachmentLoadOp loadOp, VkRenderPass *renderPass, VkImageLayout colorAttachmentFinalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
 	VkResult vhRenderCreateRenderPassOffscreen(VkDevice device, VkFormat depthFormat, VkRenderPass *renderPass);
 

--- a/VulkanEngine/VHRayTracing.cpp
+++ b/VulkanEngine/VHRayTracing.cpp
@@ -395,7 +395,7 @@ namespace vh
 		accelerationStructureBuildGeometryInfo.geometryCount = 1;
 		accelerationStructureBuildGeometryInfo.pGeometries = &accelerationStructureGeometry;
 
-		uint32_t primitive_count = blas.size();
+		uint32_t primitive_count = (uint32_t)blas.size();
 
 		VkAccelerationStructureBuildSizesInfoKHR accelerationStructureBuildSizesInfo{};
 		accelerationStructureBuildSizesInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
@@ -510,7 +510,7 @@ namespace vh
 		accelerationStructureBuildGeometryInfo.geometryCount = 1;
 		accelerationStructureBuildGeometryInfo.pGeometries = &accelerationStructureGeometry;
 
-		uint32_t primitive_count = blas.size();
+		uint32_t primitive_count = (uint32_t)blas.size();
 
 		VkAccelerationStructureBuildSizesInfoKHR accelerationStructureBuildSizesInfo{};
 		accelerationStructureBuildSizesInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;

--- a/VulkanEngine/VHRender.cpp
+++ b/VulkanEngine/VHRender.cpp
@@ -27,7 +27,8 @@ namespace vh
 		VkFormat swapChainImageFormat,
 		VkFormat depthFormat,
 		VkAttachmentLoadOp loadOp,
-		VkRenderPass *renderPass)
+		VkRenderPass *renderPass,
+		VkImageLayout colorAttachmentFinalLayout)
 	{
 		VkAttachmentDescription colorAttachment = {};
 		colorAttachment.format = swapChainImageFormat;
@@ -42,7 +43,7 @@ namespace vh
 		{
 			colorAttachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 		}
-		colorAttachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		colorAttachment.finalLayout = colorAttachmentFinalLayout;
 
 		VkAttachmentDescription depthAttachment = {};
 		depthAttachment.format = depthFormat;


### PR DESCRIPTION
Allow the CPU to calculate the next frame while the GPU is rendering the previous frame. With this change the CPU does not need to wait for the completion of GPU rendering.
This needed changes of the synchronization in various places, to be able to remove fences (on image layout transition) and vkQueueWaitIdle (in nuklear) calls. Some of them are still not optimal, like descriptor updates (see VESubrenderFW::addMaps and VESubrenderFW::removeEntity).
Forward renderer tested successfully. (Other renderer also work, but show the known limitations.)