### PR TITLE
ifdefs for linux support

### DIFF
--- a/include/VHInclude.h
+++ b/include/VHInclude.h
@@ -69,7 +69,11 @@ namespace vve {
 
 #include <VkBootstrap.h>
 
+#ifdef __linux__
+#include <vk_mem_alloc.h>
+#else
 #include "vma/vk_mem_alloc.h"
+#endif
 
 #include "imgui.h"
 #include "backends/imgui_impl_sdl2.h"

--- a/src/VHVulkan.cpp
+++ b/src/VHVulkan.cpp
@@ -37,10 +37,18 @@
 #include <stb_image_write.h>
 
 #define VOLK_IMPLEMENTATION
+#ifdef __linux__
+#include <volk.h>
+#else
 #include "volk/volk.h"
+#endif
 
 #define VMA_IMPLEMENTATION
+#ifdef __linux__
+#include <vk_mem_alloc.h>
+#else
 #include "vma/vk_mem_alloc.h"
+#endif
 
 #define IMGUI_IMPL_VULKAN_USE_VOLK
 #include "imgui.h"


### PR DESCRIPTION
Under Ubuntu 24.04 (and I guess most Linux distributions) the provided packages install the volk and VMA headers directly under "/usr/include".