### PR TITLE
Improve frame grabber performance (and some VS settings)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.0)
+cmake_minimum_required (VERSION 3.8.0)
 project (
   "ViennaVulkanEngine"
   VERSION 2.0.0
@@ -188,6 +188,10 @@ add_subdirectory(examples)
 include(CTest)
 add_subdirectory(tests)
 
+# set the game as the default startup project in VS
+if(MSVC)
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT game)
+endif()
 
 # Doxygen
 find_package(Doxygen)

--- a/examples/game/CMakeLists.txt
+++ b/examples/game/CMakeLists.txt
@@ -6,5 +6,10 @@ add_executable(${TARGET} ${SOURCE} ${HEADERS})
 
 target_compile_features(${TARGET} PUBLIC cxx_std_20)
 
+# set the repository root directory as the debug working directory for this target in VS
+if(MSVC)
+    set_property(TARGET ${TARGET} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+endif()
+
 target_link_libraries (${TARGET} PUBLIC viennavulkanengine)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,11 @@ add_library (${TARGET} STATIC ${SOURCE} ${HEADERS})
 
 target_compile_features(${TARGET} PUBLIC cxx_std_20)
 
+# Build in parallel under Visual Studio. Not enabled by default.
+if(MSVC AND NOT USE_CLANG)
+  target_compile_options(${TARGET} PRIVATE "/MP")
+endif()
+
 source_group(
   TREE "${PROJECT_SOURCE_DIR}/include"
   PREFIX "Header Files"

--- a/src/VHImage.cpp
+++ b/src/VHImage.cpp
@@ -231,7 +231,7 @@ namespace vh {
         VmaAllocationInfo allocInfo;
 
         BufCreateBuffer(allocator, (VkDeviceSize)imageSize, VK_BUFFER_USAGE_TRANSFER_DST_BIT, 
-            VMA_MEMORY_USAGE_CPU_ONLY, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT,
+            VMA_MEMORY_USAGE_CPU_ONLY, VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT,
             stagingBuffer, stagingBufferAllocation, &allocInfo);
 
 		ImgTransitionImageLayout(device, graphicsQueue, commandPool, image, format, 


### PR DESCRIPTION
Improves performance of frame grabber (use HOST_CACHED memory):
* with JPG write: 23 -> 28 FPS
* without JPG write: 90 -> 370 FPS

Sets some convenience settings for VS:
* parallel build
* default startup project to "game"
* working directory for debugger