### PR TITLE
ADD - xrel and yrel data in MsgMouseMove

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ include_directories(${glm_SOURCE_DIR}/src)
 
 FetchContent_Declare(vkbootstrap
                      GIT_REPOSITORY https://github.com/charles-lunarg/vk-bootstrap.git 
-                     GIT_TAG main)
+                     GIT_TAG v1.4.339)
 FetchContent_MakeAvailable(vkbootstrap)
 include_directories(${vkbootstrap_SOURCE_DIR}/src)
 

--- a/include/VESystem.h
+++ b/include/VESystem.h
@@ -125,7 +125,7 @@ namespace vve {
 		//------------------------------------------------------------------------------------------------
 
 		/** @brief Message for mouse move events */
-		struct MsgMouseMove : public MsgBase { MsgMouseMove(double dt, float x, float y); float m_x; float m_y; };
+		struct MsgMouseMove : public MsgBase { MsgMouseMove(double dt, float x, float y, float xrel, float yrel); float m_x; float m_y; float m_xrel; float m_yrel; };
 	    /** @brief Message for mouse button down events */
 	    struct MsgMouseButtonDown : public MsgBase { MsgMouseButtonDown(double dt, int button); int m_button; };
 	    /** @brief Message for mouse button up events */

--- a/src/VESystem.cpp
+++ b/src/VESystem.cpp
@@ -36,7 +36,7 @@ namespace vve {
     
 	//------------------------------------------------------------------------
 
-	System::MsgMouseMove:: MsgMouseMove(double dt, float x, float y): MsgBase{"SDL_MOUSE_MOVE", dt}, m_x{x}, m_y{y} {}; 
+    System::MsgMouseMove:: MsgMouseMove(double dt, float x, float y, float xrel, float yrel): MsgBase{"SDL_MOUSE_MOVE", dt}, m_x{x}, m_y{y}, m_xrel{xrel}, m_yrel{yrel} {}; 
     System::MsgMouseButtonDown:: MsgMouseButtonDown(double dt, int button): MsgBase{"SDL_MOUSE_BUTTON_DOWN", dt}, m_button{button} {}; 
     System::MsgMouseButtonUp::MsgMouseButtonUp(double dt, int button): MsgBase{"SDL_MOUSE_BUTTON_UP", dt}, m_button{button} {}; 
     System::MsgMouseButtonRepeat::MsgMouseButtonRepeat(double dt, int button): MsgBase{"SDL_MOUSE_BUTTON_REPEAT", dt}, m_button{button} {}; 

--- a/src/VEWindowSDL.cpp
+++ b/src/VEWindowSDL.cpp
@@ -149,7 +149,7 @@ namespace vve {
                     wstate().m_isMinimized = false;
                 	break;
                 case SDL_EVENT_MOUSE_MOTION:
-                    m_engine.SendMsg( MsgMouseMove{message.GetDt(), event.motion.x, event.motion.y} );
+                    m_engine.SendMsg( MsgMouseMove{message.GetDt(), event.motion.x, event.motion.y, event.motion.xrel, event.motion.yrel} );
                     break;
                 case SDL_EVENT_MOUSE_BUTTON_DOWN:
                     m_engine.SendMsg( MsgMouseButtonDown{message.GetDt(), event.button.button} );


### PR DESCRIPTION
In order to make first person camera control using SDL_SetWindowRelativeMouseMode work as expected, I require the xrel and yrel data from SDL mouse movement events. This pull request extends the existing MsgMouseMove with the aforementioned properties.

Please advise if this change is desired in the main repository of the VVE. If not, I can also work with my fork.