### PR TITLE
fix: replace hard-coded int by MAX_FRAMES_IN_FLIGHT

### DIFF
--- a/include/VHCommand.h
+++ b/include/VHCommand.h
@@ -79,7 +79,7 @@ namespace vvh {
 
 	template<typename T = ComCreateCommandBuffersInfo>
 	inline void ComCreateCommandBuffers(T&& info) {
-		if (info.m_commandBuffers.size() == 0) info.m_commandBuffers.resize(2);
+		if (info.m_commandBuffers.size() == 0) info.m_commandBuffers.resize(MAX_FRAMES_IN_FLIGHT);
 
 		VkCommandBufferAllocateInfo allocInfo{};
 		allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;

--- a/src/VHCommand.cpp
+++ b/src/VHCommand.cpp
@@ -80,7 +80,7 @@ namespace vvh {
      * @param commandBuffers Vector to store allocated command buffers (resized to 2 if empty)
      */
     void ComCreateCommandBuffers(VkDevice device, VkCommandPool commandPool, std::vector<VkCommandBuffer>& commandBuffers) {
-        if(commandBuffers.size() == 0) commandBuffers.resize(2);
+        if(commandBuffers.size() == 0) commandBuffers.resize(MAX_FRAMES_IN_FLIGHT);
 
         VkCommandBufferAllocateInfo allocInfo{};
         allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;


### PR DESCRIPTION
for some reason, the MAX_FRAMES_IN_FLIGHT in ComCreateCommandBuffers was hard-coded.