### PR TITLE
Add optional post-processing pass to the forward renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,15 @@ elseif(EXISTS "${VVE_VCPKG_INSTALLED_DIR}/share/SDL3/SDL3Config.cmake")
 endif()
 
 find_package(Vulkan REQUIRED)
+
+# Vienna Vulkan Post Processing Library
+include(FetchContent)
+FetchContent_Declare(viennavulkanpostprocessinglibrary
+                     GIT_REPOSITORY https://github.com/orcunilker/ViennaVulkanPostProcessingLibrary.git
+                     GIT_TAG v0.1)
+FetchContent_MakeAvailable(viennavulkanpostprocessinglibrary)
+set_target_properties(vvppl PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 find_package(slang CONFIG QUIET)
 if(TARGET slang::slang AND NOT VVE_VULKAN_SDK_ROOT STREQUAL "" AND EXISTS "${VVE_VULKAN_SDK_ROOT}/include/slang/slang.h")
    get_target_property(VVE_SLANG_IMPORTED_INCLUDES slang::slang INTERFACE_INCLUDE_DIRECTORIES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,3 +21,7 @@ endif()
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/simple_forward_demo/CMakeLists.txt")
     add_subdirectory(simple_forward_demo)
 endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/postprocessing/CMakeLists.txt")
+    add_subdirectory(postprocessing)
+endif()

--- a/examples/postprocessing/CMakeLists.txt
+++ b/examples/postprocessing/CMakeLists.txt
@@ -1,0 +1,17 @@
+find_package(imgui CONFIG REQUIRED)
+
+add_executable(postprocessing
+    postprocessing.cpp
+)
+
+target_link_libraries(postprocessing PRIVATE
+    ViennaVulkanEngine::ViennaVulkanEngine
+    imgui::imgui
+)
+
+add_dependencies(postprocessing
+    ViennaVulkanEngine
+    vve_simple_shaders
+)
+
+vve_set_output_dirs(postprocessing)

--- a/examples/postprocessing/postprocessing.cpp
+++ b/examples/postprocessing/postprocessing.cpp
@@ -1,0 +1,223 @@
+#include <imgui.h>
+#include <VVPPL.h>
+
+import std;
+import VEEngine;
+
+/**
+ * @file
+ * @brief Adopted from testscene. Post Processing Demo.
+ */
+namespace {
+constexpr auto crateTextureRelativePath = "assets/game/crate0/diffuse.png";	
+
+/// @brief Finds the repository-style asset root from either the cwd or executable location.
+[[nodiscard]] std::filesystem::path assetRoot(char *argv0) {
+	auto containsGameAssets = [](const std::filesystem::path &candidate) {
+		return std::filesystem::exists(candidate / crateTextureRelativePath);
+	};
+	if (const auto cwd = std::filesystem::current_path(); containsGameAssets(cwd)) {
+		return cwd;
+	}
+	if (argv0 == nullptr) {
+		return {};
+	}
+	auto executable = std::filesystem::absolute(std::filesystem::path{argv0});
+	if (std::filesystem::exists(executable)) {
+		executable = std::filesystem::weakly_canonical(executable);
+	}
+	for (auto candidate = executable.parent_path(); !candidate.empty(); candidate = candidate.parent_path()) {
+		if (containsGameAssets(candidate)) {
+			return candidate;
+		}
+		if (candidate == candidate.root_path()) {
+			break;
+		}
+	}
+	return {};
+}
+
+/// @brief Reads the optional frame count used by automated example runs.
+[[nodiscard]] std::optional<int> frameLimit(int argc, char **argv) {
+	for (int index = 1; index + 1 < argc; ++index) {
+		if (argv[index] == nullptr || argv[index + 1] == nullptr) {
+			continue;
+		}
+		if (std::string_view{argv[index]} != "--frames") {
+			continue;
+		}
+		int value{};
+		const std::string_view text{argv[index + 1]};
+		const auto result = std::from_chars(text.data(), text.data() + text.size(), value);
+		if (result.ec == std::errc{} && value >= 0) {
+			return value;
+		}
+	}
+	return std::nullopt;
+}
+
+/// @brief Adds the game floor and three crate cubes through facade scene authoring calls.
+[[nodiscard]] std::expected<void, vve::Error> loadGameScene(vve::RenderSystem render, const std::filesystem::path &root) {
+	constexpr vve::Vec3 cubeMinimum{-0.5F, -0.5F, -0.5F}; ///< Unit cube lower corner.
+	constexpr vve::Vec3 cubeMaximum{0.5F, 0.5F, 0.5F};    ///< Unit cube upper corner.
+	constexpr float cubeCenterY = 0.5F;                   ///< Unit cube bottom sits on the y=0 ground plane.
+	const auto crateTexture = root / crateTextureRelativePath; ///< Crate diffuse texture.
+
+	render.clearScene();
+	if (auto result = render.addPlane(vve::Vec2{6.0F, 4.0F}, vve::LinearColor{.value = vve::Vec3{0.1F, 0.6F, 0.2F}});
+		 !result) {
+		return std::unexpected(result.error());
+	}
+	for (const vve::Vec3 center : std::array{vve::Vec3{-1.5F, cubeCenterY, -0.5F},
+														  vve::Vec3{0.0F, cubeCenterY, 0.75F},
+														  vve::Vec3{1.5F, cubeCenterY, -0.5F}}) {
+		if (auto result = render.addTexturedCuboid(cubeMinimum, cubeMaximum, crateTexture,
+																 vve::Transform{.translation = vve::Position{.value = center}});
+			 !result) {
+			return std::unexpected(result.error());
+		}
+	}
+	return {};
+}
+
+} // namespace
+
+/**
+ * @brief Runs a small interactive scene using only the public VVE facade.
+ */
+int main(int argc, char **argv) {
+	std::cout << std::unitbuf;
+	std::cerr << std::unitbuf;
+	std::cout << "[postprocessing] engine=" << vve::engineImplementationNamespaceName << '\n';
+
+	const auto activeRenderer = vve::RendererId{.value = "forward"}; ///< Renderer id selected through the facade.
+	auto engine = vve::EngineBuilder<>{}
+						 .applicationName("postprocessing")
+						 .addWindow(vve::WindowSetup{}
+										 .id("main")
+										 .title("VVE Post Processing")
+										 .extent(vve::PixelExtent{.width = 960, .height = 540})
+										 .renderer(activeRenderer)
+										 .resizable(true))
+						 .build();
+
+	if (const auto result = engine.init(); !result) {
+		std::cerr << "[postprocessing] engine init failed: error=" << vve::errorName(result.error()) << '\n';
+		return 1;
+	}
+
+	auto render = engine.world().get<vve::RenderSystem>();
+
+	// Keep access to the library's effect settings.
+	vvppl::TonemapSettings *tonemap{nullptr};
+	vvppl::ChromaticSettings *chromatic{nullptr};
+	vvppl::GreyscaleSettings *greyscale{nullptr};
+	vvppl::VignetteSettings *vignette{nullptr};
+	vvppl::FilmGrainSettings *grain{nullptr};
+
+	// Configure the effects when the renderer creates the chain.
+	render.setPostProcessSetup(
+    	[&tonemap, &chromatic, &greyscale, &vignette, &grain](vvppl::PostProcessing &pp) {
+			tonemap = &pp.addTonemap();
+			chromatic = &pp.addChromatic();
+			greyscale = &pp.addGreyscale();
+			vignette = &pp.addVignette();
+			grain = &pp.addFilmGrain();
+
+			tonemap->exposure = 0.6F;
+			chromatic->intensity = 0.02F;
+			greyscale->strength = 0.2F;
+			vignette->intensity = 0.8F;
+			vignette->radius = 0.4F;
+			vignette->smoothness = 0.6F;
+			grain->intensity = 0.05F;
+    });
+
+	if (const auto result = loadGameScene(render, assetRoot(argc > 0 ? argv[0] : nullptr)); !result) {
+		std::cerr << "[postprocessing] scene load failed: error=" << vve::errorName(result.error()) << '\n';
+		return 2;
+	}
+
+	// Simple Lights
+	const auto white = vve::LinearColor{.value = vve::Vec3{1.0F, 1.0F, 1.0F}};
+	const auto ambient = vve::LinearColor{.value = vve::Vec3{0.05F, 0.05F, 0.05F}};
+	render.setDirectionalLight(vve::Direction{.value = vve::Vec3{-0.5F, -1.0F, 0.5F}}, white,
+							vve::LightIntensity{.value = 1.0F}, ambient);
+	render.setPointLight(vve::Position{.value = vve::Vec3{2.0F, 4.0F, 2.0F}}, white,
+						vve::LightIntensity{.value = 3.0F}, vve::LightRange{.value = 8.0F}, ambient);
+
+	const int maxFrames = frameLimit(argc, argv).value_or(0);
+	int frame{};
+	bool running = true;                                                                 ///< GUI changes are applied after the frame callback returns.
+	double renderFps{};                                                                              ///< Render-system FPS, not the ImGui/display estimate.
+	vve::DefaultCameraController cameraController{};                                                ///< Facade camera motion shared by examples and applications.
+	cameraController.eye = vve::Position{.value = vve::Vec3{-2.0F, 1.5F, 6.0F}};
+	const auto startupForward =
+		vve::math::normalize(vve::math::subtract(vve::Vec3{0.0F, 1.0F, 0.0F}, cameraController.eye.value));
+	cameraController.yaw = std::atan2(startupForward.x, -startupForward.z);
+	cameraController.pitch = std::asin(startupForward.y);
+	engine.world().get<vve::GuiSystem>().draw([&frame, &activeRenderer, &cameraController, &renderFps,
+															 &tonemap, &chromatic, &greyscale, &vignette, &grain] {
+		ImGui::SetNextWindowSize(ImVec2(340.0F, 280.0F), ImGuiCond_Always);
+		ImGui::Begin("Post Processing");
+		ImGui::PushItemWidth(160.0F);
+		// Adjust the effect settings directly.
+		if (tonemap) {
+			ImGui::SliderFloat("Exposure", &tonemap->exposure, 0.0F, 3.0F);
+		}
+		if (chromatic) {
+			ImGui::SliderFloat("Chromatic aberration",
+							&chromatic->intensity, 0.0F, 0.03F, "%.3f");
+		}
+		if (greyscale) {
+			ImGui::SliderFloat("Greyscale", &greyscale->strength, 0.0F, 1.0F);
+		}
+		if (vignette) {
+			ImGui::SliderFloat("Vignette", &vignette->intensity, 0.0F, 1.0F);
+			ImGui::SliderFloat("Vignette radius", &vignette->radius, 0.0F, 1.0F);
+			ImGui::SliderFloat("Vignette smoothness",
+							&vignette->smoothness, 0.01F, 1.0F);
+		}
+		if (grain) {
+			ImGui::SliderFloat("Film grain", &grain->intensity, 0.0F, 0.3F);
+		}
+		ImGui::Separator();
+
+		ImGui::Text("Frame: %d", frame);
+		ImGui::Text("Render FPS: %.1f", renderFps);
+		ImGui::Text("Renderer: %s", activeRenderer.value.c_str());
+		ImGui::Text("Camera: %.2f, %.2f, %.2f", cameraController.eye.value.x, cameraController.eye.value.y,
+						cameraController.eye.value.z);
+
+		ImGui::PopItemWidth();
+		ImGui::End();
+	});
+	
+	const auto startTime = std::chrono::steady_clock::now(); // Clock for Film Grain shader
+
+	while (running && (maxFrames == 0 || frame < maxFrames)) {
+		const auto frameInput = engine.world().get<vve::WindowSystem>().input();
+		render.setCamera(cameraController.update(frameInput), vve::PixelExtent{.width = 960, .height = 540});
+		renderFps = render.renderingFramesPerSecond();
+
+		// New seed with every frame for the shader - time
+		if (grain) {
+			grain->time = std::chrono::duration<float>(
+				std::chrono::steady_clock::now() - startTime).count();
+		}
+
+		const auto status = engine.step();
+		if (!status) {
+			std::cerr << "[postprocessing] frame failed: error=" << vve::errorName(status.error()) << '\n';
+			return 3;
+		}
+		++frame;
+		if (*status == vve::FrameStatus::stopped) { break; }
+
+		auto input = engine.world().get<vve::WindowSystem>().input();
+		if (input.wasKeyPressed(vve::Key::escape)) { running = false; }
+	}
+
+	std::cout << "[postprocessing] frames=" << frame << '\n';
+	return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,7 @@ target_link_libraries(ViennaVulkanEngine
     PUBLIC
         assimp::assimp
         glm::glm
+        vvppl
     PRIVATE
         imgui::imgui
         SDL3::SDL3

--- a/src/RenderSystem.cpp
+++ b/src/RenderSystem.cpp
@@ -1,3 +1,6 @@
+module;
+#include <VVPPL.h>
+
 module VEEngine;
 import :RenderSystem;
 
@@ -38,6 +41,9 @@ namespace vve {
 						  LightIntensity{.value = 2.2F}, LightRange{.value = 5.8F}, SpotConeAngle{.radians = 0.58F});
 		return {};
 	}
+
+	/// @brief Sets the post processing setup
+	void RenderSystem::setPostProcessSetup(std::function<void(vvppl::PostProcessing &)> setup) { impl_.setPostProcessSetup(std::move(setup)); }
 
 	/// @brief Sets the active scene camera.
 	void RenderSystem::setCamera(Camera camera, PixelExtent extent) { impl_.setCamera(std::move(camera), extent); }

--- a/src/RenderSystem.ixx
+++ b/src/RenderSystem.ixx
@@ -1,3 +1,6 @@
+module;
+#include <VVPPL.h>
+
 export module VEEngine:RenderSystem;
 import std;
 import :Implementation;
@@ -39,6 +42,7 @@ export namespace vve {
 
 		auto clearScene()																													-> void;
 		[[nodiscard]] auto loadSampleScene()																						-> std::expected<void, Error>;
+		auto setPostProcessSetup(std::function<void(vvppl::PostProcessing &)> setup)											-> void;
 		auto setCamera(Camera camera, PixelExtent extent)																		-> void;
 		void setDirectionalLight(Direction direction_to_light, LinearColor color,
 											LightIntensity intensity, LinearColor ambient);

--- a/src/versions/simple/Render/RenderSystem.ixx
+++ b/src/versions/simple/Render/RenderSystem.ixx
@@ -6,6 +6,7 @@ module;
 #else
 #include <imgui_impl_vulkan.h>
 #endif
+#include <VVPPL.h>
 
 export module VEEngine.Simple:RenderSystem;
 import std;
@@ -110,6 +111,7 @@ export namespace vve::simple {
 		/// @brief Stores the borrowed GUI system for later forwarding to renderer backends.
 		auto setGuiSystem(void *gui)																								-> void;
 		auto setGuiRecordSink(std::function<void(VkCommandBuffer)> sink)												-> void;
+		auto setPostProcessSetup(std::function<void(vvppl::PostProcessing &)> setup)											-> void;
 		[[nodiscard]] auto initialize(SDL_Window *window, RendererId id = {})												-> std::expected<void, Error>;
 		[[nodiscard]] auto makeGuiInitInfo() const																			-> std::optional<ImGui_ImplVulkan_InitInfo>;
 		[[nodiscard]] auto forward()																								-> ForwardRenderer &;
@@ -226,6 +228,11 @@ namespace vve::simple {
 		renderer_.setGuiRecordSink(std::move(sink));
 	}
 
+	/// @brief Forwards the post processing setup into the active forward renderer.
+	inline auto RenderSystem::setPostProcessSetup(std::function<void(vvppl::PostProcessing &)> setup) -> void {
+		renderer_.setPostProcessSetup(std::move(setup));
+	}
+
 	inline auto RenderSystem::initialize(SDL_Window *window, RendererId id)									-> std::expected<void, Error>{
 		if (initialized_) { return {}; }
 		if (window == nullptr) { return std::unexpected(Error::invalid_argument); }
@@ -246,7 +253,8 @@ namespace vve::simple {
 			.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO,
 			.colorAttachmentCount = 1U,
 			.pColorAttachmentFormats = &renderer_.swapchain.imageFormat,
-			.depthAttachmentFormat = depthFormat,	///< GUI records inside the forward color pass, which binds the depth image.
+			.depthAttachmentFormat = VK_FORMAT_UNDEFINED,
+			// the GUI is drawn in a own pass after post processing, which does not have any depthAttachment
 		};
 		if (info.Device == VK_NULL_HANDLE || info.DescriptorPool == VK_NULL_HANDLE) {
 			return std::nullopt;

--- a/src/versions/simple/Render/Renderer.ixx
+++ b/src/versions/simple/Render/Renderer.ixx
@@ -6,6 +6,7 @@ module;
 #else
 #include <imgui_impl_vulkan.h>
 #endif
+#include <VVPPL.h>
 
 export module VEEngine.Simple.Renderer;
 import std;
@@ -97,6 +98,7 @@ export namespace vve::simple {
 		VulkanSwapchain swapchain{};           ///< Owned swapchain wrapper for presentation images.
 		VulkanImageViews imageViews{};         ///< Owned color image views for swapchain images.
 		VulkanImage depthImage{};              ///< Owned swapchain-sized depth attachment image and view.
+		VulkanImage hdrImage{};                ///< Owned swapchain-sized RGBA16F color target the scene is rendered into.
 		ShadowMap dirShadowArray{};            ///< Owned directional shadow-map texture array with one layer per active directional light.
 		ShadowMap spotShadowArray{};           ///< Owned spot shadow-map texture array with one layer per active spot light.
 		ShadowMap pointShadowArray{};          ///< Owned point shadow-map texture array with six layers per shadowed point light.
@@ -126,6 +128,7 @@ export namespace vve::simple {
 		Vec3 cameraTarget{zero(), one(), zero()}; ///< World-space point looked at by the frame view matrix.
 		std::optional<std::uint32_t> lastRenderedImageIndex{}; ///< Swapchain image index from the last acquired, rendered, and presented frame.
 		std::optional<VkResult> lastReadbackCaptureResult{}; ///< Result from the optional in-frame color readback.
+		std::unique_ptr<vvppl::PostProcessing> postProcess{}; ///< Owned post-processing chain applied to the finished color image.
 
 		~ForwardRenderer() { cleanup(); }
 
@@ -162,6 +165,9 @@ export namespace vve::simple {
 
 		/// @brief Stores the optional GUI command recorder used inside the forward color pass.
 		void setGuiRecordSink(std::function<void(VkCommandBuffer)> sink) { guiRecord_ = std::move(sink); }
+
+		/// @brief Stores the post processing setup, which sets and configures effects.
+		void setPostProcessSetup(std::function<void(vvppl::PostProcessing &)> setup){ postProcessSetup_ = std::move(setup); }
 
 		/// @brief Reports whether the renderer currently owns a live Vulkan device.
 		[[nodiscard]] bool initialized() const { return device.device != VK_NULL_HANDLE; }
@@ -255,6 +261,7 @@ export namespace vve::simple {
 		VkDescriptorPool imguiDescriptorPool_{VK_NULL_HANDLE}; ///< Owned Dear ImGui descriptor pool reserved for backend texture descriptors.
 		void *guiSystem_{nullptr}; ///< Non-owning, type-erased GUI system pointer reserved for later GUI integration.
 		std::function<void(VkCommandBuffer)> guiRecord_; ///< Optional GUI recorder invoked during the forward color pass.
+		std::function<void(vvppl::PostProcessing &)> postProcessSetup_; ///< Optional Post Processing setup
 		std::vector<std::filesystem::path> uploadedTextures_{}; ///< Scene::textures as of the last GPU texture upload.
 		bool sceneResourcesDirty_{true}; ///< CPU scene topology or texture changed after the last GPU synchronization.
 		bool sceneRequiresFullUpload_{true}; ///< Removal or replacement requires rebuilding index-aligned GPU meshes.

--- a/src/versions/simple/Render/RendererDraw.cpp
+++ b/src/versions/simple/Render/RendererDraw.cpp
@@ -1,5 +1,6 @@
 module;
 #include <vulkan/vulkan_core.h>
+#include <VVPPL.h>
 
 module VEEngine.Simple.Renderer;
 import std;
@@ -242,7 +243,7 @@ namespace vve::simple {
 				.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 				.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
 				.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-				.image = swapchain.images[imageIndex],
+				.image = hdrImage.image,
 				.subresourceRange = colorRange,
 			},
 			{
@@ -261,7 +262,7 @@ namespace vve::simple {
 									0U, 0U, nullptr, 0U, nullptr, static_cast<std::uint32_t>(beginBarriers.size()), beginBarriers.data());
 		const VkRenderingAttachmentInfo colorAttachment{ // Dynamic rendering mirrors the old render-pass color clear/store ops.
 			.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
-			.imageView = imageViews.ownedViews[imageIndex],
+			.imageView = hdrImage.imageView,
 			.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 			.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
 			.storeOp = VK_ATTACHMENT_STORE_OP_STORE,
@@ -289,9 +290,88 @@ namespace vve::simple {
 		vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphicsPipeline.pipeline);
 		vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout.pipelineLayout, 0U, 1U, &descriptorSets.descriptorSets[frameIndex], 0U, nullptr);
 		drawUploadedObjects(0U, false);
-		if (guiRecord_) { guiRecord_(commandBuffer); }
 
 		vkCmdEndRendering(commandBuffer);
+
+		// Both images need Layout GENERAL because HDR image gets read and Swapchain image gets written
+		const std::array<VkImageMemoryBarrier, 2U> postBarriers{{
+			{
+				.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+				.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+				.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+				.newLayout = VK_IMAGE_LAYOUT_GENERAL, // VVPPL Library needs General
+				.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+				.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+				.image = hdrImage.image,
+				.subresourceRange = colorRange,
+			},
+			{
+				.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				.srcAccessMask = 0,
+				.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+				.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED, // old content is being deleted
+				.newLayout = VK_IMAGE_LAYOUT_GENERAL, // VVPPL Library gives General
+				.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+				.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+				.image = swapchain.images[imageIndex],
+				.subresourceRange = colorRange,
+			}
+		}};
+
+		vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+							VK_PIPELINE_STAGE_TRANSFER_BIT, 0U, 0U, nullptr, 0U, nullptr,
+							static_cast<std::uint32_t>(postBarriers.size()), postBarriers.data());
+
+		
+		if (postProcess) {
+			// Post Processing
+			postProcess->apply(commandBuffer, hdrImage.image, swapchain.images[imageIndex], frameIndex);
+		} else {
+			// Same blit the library would do, without the library (rendered HDR image to Swapchain Image)
+			VkImageBlit blit{};
+			blit.srcSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .mipLevel = 0U, .baseArrayLayer = 0U, .layerCount = 1U};
+			blit.srcOffsets[1] = {static_cast<std::int32_t>(swapchain.extent.width),
+										 static_cast<std::int32_t>(swapchain.extent.height), 1};
+			blit.dstSubresource = blit.srcSubresource;
+			blit.dstOffsets[1] = blit.srcOffsets[1];
+			vkCmdBlitImage(commandBuffer, hdrImage.image, VK_IMAGE_LAYOUT_GENERAL,
+								swapchain.images[imageIndex], VK_IMAGE_LAYOUT_GENERAL, 1U, &blit, VK_FILTER_NEAREST);
+		}
+
+		// Render GUI
+		const VkImageMemoryBarrier guiBarrier {
+			.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+			.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+			.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+			.oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+			.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+			.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			.image = swapchain.images[imageIndex],
+			.subresourceRange = colorRange,
+		};
+		vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 
+							0U, 0U, nullptr, 0U, nullptr, 1U, &guiBarrier);
+
+		const VkRenderingAttachmentInfo guiAttachment{
+			.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+			.imageView = imageViews.ownedViews[imageIndex],
+			.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+			.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+			.storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+		};
+		const VkRenderingInfo guiRenderingInfo{
+			.sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
+			.renderArea = {.offset = {0, 0}, .extent = swapchain.extent},
+			.layerCount = 1U,
+			.colorAttachmentCount = 1U,
+			.pColorAttachments = &guiAttachment,
+		};
+		vkCmdBeginRendering(commandBuffer, &guiRenderingInfo);
+		if (guiRecord_) { guiRecord_(commandBuffer); }
+		vkCmdEndRendering(commandBuffer);
+
 		const VkImageMemoryBarrier presentBarrier{
 			.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
 			.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,

--- a/src/versions/simple/Render/RendererResources.cpp
+++ b/src/versions/simple/Render/RendererResources.cpp
@@ -1,6 +1,7 @@
 module;
 #include <SDL3/SDL_video.h>
 #include <vulkan/vulkan_core.h>
+#include <VVPPL.h>
 #if __has_include(<backends/imgui_impl_vulkan.h>)
 #include <backends/imgui_impl_vulkan.h>
 #else
@@ -18,6 +19,8 @@ import VEEngine.Simple.Vulkan;
 /// @brief ForwardRenderer Vulkan resource lifetime: bring-up, scene upload, swapchain rebuild, teardown, and ImGui wiring.
 
 namespace vve::simple {
+	// Format of the hdr offscreen color target the scene is rendered into.
+	constexpr VkFormat hdrFormat{VK_FORMAT_R16G16B16A16_SFLOAT};
 
 	/**
 		* @brief Initializes the Vulkan instance, device, swapchain, image views, depth attachment, shadow map, render pass, framebuffers, descriptor-set layout, pipeline layout, shader modules, graphics pipeline, command pool, command buffers, frame synchronization, per-frame uniform buffers, descriptor pool, per-frame descriptor sets, and uploaded per-object meshes.
@@ -74,6 +77,10 @@ namespace vve::simple {
 		result = depthImage.create(allocator, device.device, swapchain.extent, depthFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_ASPECT_DEPTH_BIT);
 		if (result != VK_SUCCESS) { cleanup(); return result; }
 
+		result = hdrImage.create(allocator, device.device, swapchain.extent, hdrFormat,
+										 VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_ASPECT_COLOR_BIT);
+		if (result != VK_SUCCESS) { cleanup(); return result; }
+
 		result = descriptorSetLayout.create(device.device);
 		if (result != VK_SUCCESS) { cleanup(); return result; }
 
@@ -103,7 +110,7 @@ namespace vve::simple {
 		if (result != VK_SUCCESS) { cleanup(); return result; }
 
 		result = graphicsPipeline.create(device.device, pipelineLayout.pipelineLayout, vertShaderModule.shaderModule, "vertexMain",
-															  fragShaderModule.shaderModule, vertexInput, swapchain.extent, swapchain.imageFormat, depthFormat);
+															  fragShaderModule.shaderModule, vertexInput, swapchain.extent, hdrFormat, depthFormat);
 		if (result != VK_SUCCESS) { cleanup(); return result; }
 
 		result = shadowPipeline.create(device.device, pipelineLayout.pipelineLayout, shadowShaderModule.shaderModule, "shadowVertexMain",
@@ -157,6 +164,15 @@ namespace vve::simple {
 		sceneGeometryDirty_.clear();
 		sceneResourcesDirty_ = false;
 		sceneRequiresFullUpload_ = false;
+
+		if (postProcessSetup_) {
+			// The VVPPL throws, whereas the Engine works with std::expected and VKResult
+			try {
+				postProcess = std::make_unique<vvppl::PostProcessing>(device.device, physicalDevice.physicalDevice,
+								swapchain.extent.width, swapchain.extent.height, framesInFlight);
+				postProcessSetup_(*postProcess);
+			} catch (const std::exception &) { cleanup(); return VK_ERROR_INITIALIZATION_FAILED; }
+		}
 
 		return VK_SUCCESS;
 	}
@@ -262,6 +278,7 @@ namespace vve::simple {
 			vkDestroyDescriptorPool(device.device, imguiDescriptorPool_, nullptr);
 			imguiDescriptorPool_ = VK_NULL_HANDLE;
 		}
+		postProcess.reset();
 		descriptorPool.cleanup();
 		uploadedTextures_.clear();
 		sceneGeometryDirty_.clear();
@@ -284,6 +301,7 @@ namespace vve::simple {
 		spotShadowArray.cleanup();
 		dirShadowArray.cleanup();
 		depthImage.cleanup();
+		hdrImage.cleanup();
 		imageViews.cleanup();
 		swapchain.cleanup();
 		allocator.cleanup();
@@ -318,6 +336,7 @@ namespace vve::simple {
 
 		graphicsPipeline.cleanup();
 		depthImage.cleanup();
+		hdrImage.cleanup();
 		imageViews.cleanup();
 		frameSync.cleanup();
 		swapchain.cleanup();
@@ -333,9 +352,15 @@ namespace vve::simple {
 		result = depthImage.create(allocator, device.device, swapchain.extent, depthFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_ASPECT_DEPTH_BIT);
 		if (result != VK_SUCCESS) { return result; }
 
+		result = hdrImage.create(allocator, device.device, swapchain.extent, hdrFormat,
+										 VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_ASPECT_COLOR_BIT);
+		if (result != VK_SUCCESS) { cleanup(); return result; }
+
+		if (postProcess) { postProcess->resize(swapchain.extent.width, swapchain.extent.height); }
+
 		VulkanVertexInputDescription vertexInput{};
 		result = graphicsPipeline.create(device.device, pipelineLayout.pipelineLayout, vertShaderModule.shaderModule, "vertexMain",
-													  fragShaderModule.shaderModule, vertexInput, swapchain.extent, swapchain.imageFormat, depthFormat);
+													  fragShaderModule.shaderModule, vertexInput, swapchain.extent, hdrFormat, depthFormat);
 		if (result != VK_SUCCESS) { return result; }
 
 		result = frameSync.create(device.device, framesInFlight, static_cast<std::uint32_t>(swapchain.images.size()));

--- a/src/versions/simple/Vulkan/Presentation.ixx
+++ b/src/versions/simple/Vulkan/Presentation.ixx
@@ -109,7 +109,7 @@ export namespace vve::simple {
 				.imageColorSpace = chosenFormat.colorSpace,
 				.imageExtent = chosenExtent,
 				.imageArrayLayers = 1U,
-				.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,	///< Swapchain image is rendered to and copied from for readback.
+				.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,	///< Swapchain image is rendered to, read back from, and copied into from the offscreen color target.
 				.imageSharingMode = concurrentSharing ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE,
 				.queueFamilyIndexCount = concurrentSharing ? static_cast<std::uint32_t>(queueFamilies.size()) : 0U,
 				.pQueueFamilyIndices = concurrentSharing ? queueFamilies.data() : nullptr,


### PR DESCRIPTION
The forward pass now renders into an RGBA16F offscreen image instead of the swapchain image. The finished image is copied into the swapchain afterwards, so the swapchain usage gains TRANSFER_DST.

Applications fill a post-processing chain through a setup callback registered with RenderSystem::setPostProcessSetup. Without a callback no chain is created and the renderer blits the offscreen image itself, so existing behavior is unchanged.

The GUI now records in its own pass after post-processing, which binds no depth attachment.

examples/postprocessing shows five effects with live controls.